### PR TITLE
chore: bump phoenixd from 0.6.3 to 0.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM acinq/phoenixd:0.6.3
+FROM acinq/phoenixd:0.7.2
 
 USER root
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,9 +1,11 @@
 id: phoenixd
 title: "phoenixd"
-version: 0.6.3
+version: 0.7.2
 release-notes: |
-  - Add basic configuration
-  - Add properties
+  - Upstream update: phoenixd 0.6.3 -> 0.7.2
+  - Taproot channel support (v0.7.0)
+  - Updated lightning-kmp to 1.11.4
+  - Optimized binaries
 license: Apache-2.0
 wrapper-repo: "https://github.com/Start9Labs/phoenixd-startos"
 upstream-repo: "https://github.com/ACINQ/phoenixd"


### PR DESCRIPTION
## Summary

- Bumps upstream phoenixd from 0.6.3 to 0.7.2 (minor)
- Updates `Dockerfile` base image tag and `manifest.yaml` version + release notes

## Key upstream changes

- **v0.7.0**: Taproot channel support, lightning-kmp 1.11
- **v0.7.1**: lightning-kmp 1.11.2, maintenance fixes
- **v0.7.2**: lightning-kmp 1.11.4, optimized binaries

## Files changed

- `Dockerfile` — Base image `acinq/phoenixd:0.6.3` → `acinq/phoenixd:0.7.2`
- `manifest.yaml` — Version bump and updated release notes